### PR TITLE
build: SwayFX and Non-T2 Kansei Image

### DIFF
--- a/.github/workflows/build-kansei.yml
+++ b/.github/workflows/build-kansei.yml
@@ -32,6 +32,7 @@ jobs:
           #- t2-atomic-plasma-kansei.yml
           #- t2-atomic-sway.yml
           - t2-atomic-sway-kansei.yml
+          - fedora-kansei.yml
 
     steps:
        # the build is fully handled by the reusable github action

--- a/recipes/common/common-apps-swayfx.yml
+++ b/recipes/common/common-apps-swayfx.yml
@@ -1,13 +1,9 @@
 # modules and things general to all wayland compositor recipes
 modules:
-  - type: rpm-ostree
-    repos:
-      - https://copr.fedorainfracloud.org/coprs/swayfx/swayfx/repo/fedora-%OS_VERSION%/swayfx-swayfx-fedora-%OS_VERSION%.repo
-    install:
-      - swayfx
-      - scenefx
 
   - type: rpm-ostree
+    remove:
+      - sway
     install:
       # greeters from main repos. spins that also include cosmic will include their config for greetd which doesn't conflict with these.
       # /etc/greetd/config.toml needs configuration to use tuigreet or gtkgreet, but will work with agreety (basic terminal login) out of the box.
@@ -106,6 +102,13 @@ modules:
       - breeze-icon-theme 
       - papirus-icon-theme
       - sway-wallpapers
+
+  - type: rpm-ostree
+    repos:
+      - https://copr.fedorainfracloud.org/coprs/swayfx/swayfx/repo/fedora-%OS_VERSION%/swayfx-swayfx-fedora-%OS_VERSION%.repo
+    install:
+      - swayfx
+      - scenefx
 
   - type: rpm-ostree
     repos:

--- a/recipes/common/common-apps-swayfx.yml
+++ b/recipes/common/common-apps-swayfx.yml
@@ -113,7 +113,7 @@ modules:
     install:
       - SwayNotificationCenter
 
- - type: rpm-ostree
+  - type: rpm-ostree
     repos:
       - https://copr.fedorainfracloud.org/coprs/alebastr/sway-extras/repo/fedora-%OS_VERSION%/alebastr-sway-extras-fedora-%OS_VERSION%.repo
     install:

--- a/recipes/common/common-apps-swayfx.yml
+++ b/recipes/common/common-apps-swayfx.yml
@@ -2,8 +2,14 @@
 modules:
 
   - type: rpm-ostree
-    remove:
-      - sway
+    repos:
+      - https://copr.fedorainfracloud.org/coprs/swayfx/swayfx/repo/fedora-%OS_VERSION%/swayfx-swayfx-fedora-%OS_VERSION%.repo
+    install:
+      - swayfx
+      - scenefx
+
+  - type: rpm-ostree
+
     install:
       # greeters from main repos. spins that also include cosmic will include their config for greetd which doesn't conflict with these.
       # /etc/greetd/config.toml needs configuration to use tuigreet or gtkgreet, but will work with agreety (basic terminal login) out of the box.
@@ -102,13 +108,6 @@ modules:
       - breeze-icon-theme 
       - papirus-icon-theme
       - sway-wallpapers
-
-  - type: rpm-ostree
-    repos:
-      - https://copr.fedorainfracloud.org/coprs/swayfx/swayfx/repo/fedora-%OS_VERSION%/swayfx-swayfx-fedora-%OS_VERSION%.repo
-    install:
-      - swayfx
-      - scenefx
 
   - type: rpm-ostree
     repos:

--- a/recipes/fedora-kansei.yml
+++ b/recipes/fedora-kansei.yml
@@ -12,9 +12,9 @@ image-version: 40
 
 modules:
   - from-file: common/common-files.yml
-  - from-file: common/common-files-swayfx.yml
+  - from-file: common/common-files-sway.yml
   - from-file: common/common-files-gnome.yml
-  - from-file: common/common-apps-sway.yml
+  - from-file: common/common-apps-swayfx.yml
   - from-file: common/common-files-cosmic.yml
   - from-file: common/common-apps-cosmic.yml
   - from-file: common/common-apps-gnome.yml

--- a/recipes/fedora-kansei.yml
+++ b/recipes/fedora-kansei.yml
@@ -7,18 +7,14 @@ name: fedora-kansei
 # description will be included in the image's metadata
 description: TEST NON-T2 DO NOT INSTALL Personal Sway spin testing area, swayfx or similar
 
-base-image: ghcr.io/ublue-os/sericea-main
-image-version: 40
+base-image: ghcr.io/ublue-os/bluefin-dx
+image-version: latest
 
 modules:
-  - from-file: common/common-files.yml
   - from-file: common/common-files-sway.yml
-  - from-file: common/common-files-gnome.yml
   - from-file: common/common-apps-swayfx.yml
   - from-file: common/common-files-cosmic.yml
   - from-file: common/common-apps-cosmic.yml
-  - from-file: common/common-apps-gnome.yml
-  - from-file: common/common-apps.yml
   - from-file: common/common-kansei.yml
 
   - type: rpm-ostree

--- a/recipes/fedora-kansei.yml
+++ b/recipes/fedora-kansei.yml
@@ -1,0 +1,39 @@
+#
+# 2024 Chris Lauretano <os@cdl.sh>
+#
+# Fedora Atomic spins for Apple T2
+
+name: fedora-kansei
+# description will be included in the image's metadata
+description: TEST: Personal non-T2 Sway spin testing area, swayfx or similar
+
+base-image: ghcr.io/ublue-os/sericea-main
+image-version: 40
+
+modules:
+  - from-file: common/common-files.yml
+  - from-file: common/common-files-swayfx.yml
+  - from-file: common/common-files-gnome.yml
+  - from-file: common/common-apps-sway.yml
+  - from-file: common/common-files-cosmic.yml
+  - from-file: common/common-apps-cosmic.yml
+  - from-file: common/common-apps-gnome.yml
+  - from-file: common/common-apps.yml
+  - from-file: common/common-kansei.yml
+
+  - type: rpm-ostree
+    repos:
+      - https://copr.fedorainfracloud.org/coprs/alebastr/sway-extras/repo/fedora-%OS_VERSION%/alebastr-sway-extras-fedora-%OS_VERSION%.repo
+
+    install:
+      - tofi
+      - sway-git
+      #- sway-services
+
+  - type: script
+    snippets: 
+      - "ln -sfn /usr/lib/systemd/system/greetd.service /etc/systemd/system/display-manager.service"
+
+  - type: signing # this sets up the proper policy & signing files for signed images to work fully
+  
+

--- a/recipes/fedora-kansei.yml
+++ b/recipes/fedora-kansei.yml
@@ -5,7 +5,7 @@
 
 name: fedora-kansei
 # description will be included in the image's metadata
-description: TEST: Personal non-T2 Sway spin testing area, swayfx or similar
+description: TEST NON-T2 DO NOT INSTALL Personal Sway spin testing area, swayfx or similar
 
 base-image: ghcr.io/ublue-os/sericea-main
 image-version: 40

--- a/recipes/t2-atomic-sway-kansei.yml
+++ b/recipes/t2-atomic-sway-kansei.yml
@@ -15,7 +15,7 @@ modules:
   - from-file: common/common-files.yml
   - from-file: common/common-files-sway.yml
   - from-file: common/common-files-gnome.yml
-  - from-file: common/common-apps-sway.yml
+  - from-file: common/common-apps-swayfx.yml
   - from-file: common/common-files-cosmic.yml
   - from-file: common/common-apps-cosmic.yml
   - from-file: common/common-apps-gnome.yml

--- a/recipes/t2-atomic-sway-kansei.yml
+++ b/recipes/t2-atomic-sway-kansei.yml
@@ -13,9 +13,9 @@ image-version: 40
 modules:
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
   - from-file: common/common-files.yml
-  - from-file: common/common-files-swayfx.yml
+  - from-file: common/common-files-sway.yml
   - from-file: common/common-files-gnome.yml
-  - from-file: common/common-apps-sway.yml
+  - from-file: common/common-apps-swayfx.yml
   - from-file: common/common-files-cosmic.yml
   - from-file: common/common-apps-cosmic.yml
   - from-file: common/common-apps-gnome.yml

--- a/recipes/t2-atomic-sway-kansei.yml
+++ b/recipes/t2-atomic-sway-kansei.yml
@@ -5,7 +5,7 @@
 
 name: t2-atomic-sway-kansei
 # description will be included in the image's metadata
-description: TEST: Personal Sway spin testing area, swayfx or similar
+description: TEST Personal Sway spin testing area, swayfx or similar
 
 base-image: ghcr.io/ublue-os/sericea-main
 image-version: 40

--- a/recipes/t2-atomic-sway-kansei.yml
+++ b/recipes/t2-atomic-sway-kansei.yml
@@ -7,7 +7,7 @@ name: t2-atomic-sway-kansei
 # description will be included in the image's metadata
 description: TEST Personal Sway spin testing area, swayfx or similar
 
-base-image: ghcr.io/ublue-os/sericea-main
+base-image: ghcr.io/ublue-os/base-main
 image-version: 40
 
 modules:

--- a/recipes/t2-atomic-sway-kansei.yml
+++ b/recipes/t2-atomic-sway-kansei.yml
@@ -15,7 +15,7 @@ modules:
   - from-file: common/common-files.yml
   - from-file: common/common-files-sway.yml
   - from-file: common/common-files-gnome.yml
-  - from-file: common/common-apps-swayfx.yml
+  - from-file: common/common-apps-sway.yml
   - from-file: common/common-files-cosmic.yml
   - from-file: common/common-apps-cosmic.yml
   - from-file: common/common-apps-gnome.yml


### PR DESCRIPTION
this branch enables the t2-atomic-sway-kansei image with swayfx, and adds a non-T2 swayfx image for testing on a personal system.