### PR TITLE
fix: switching from fsync kernel to t2linux kernel 

### DIFF
--- a/recipes/t2-atomic-cosmic-gnome.yml
+++ b/recipes/t2-atomic-cosmic-gnome.yml
@@ -12,7 +12,7 @@ image-version: 40
 
 modules:
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync.yml #pulls fsync containerfile and overrides base image kernel
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-cosmic.yml
   - from-file: common/common-files-gnome.yml

--- a/recipes/t2-atomic-cosmic-plasma.yml
+++ b/recipes/t2-atomic-cosmic-plasma.yml
@@ -12,7 +12,7 @@ image-version: 40
 
 modules:
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync.yml #pulls fsync containerfile and overrides base image kernel
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-cosmic.yml
   - from-file: common/common-files-plasma.yml

--- a/recipes/t2-atomic-cosmic.yml
+++ b/recipes/t2-atomic-cosmic.yml
@@ -12,7 +12,7 @@ image-version: 40
 
 modules:
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync.yml #pulls fsync containerfile and overrides base image kernel
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-cosmic.yml
   - from-file: common/common-apps.yml

--- a/recipes/t2-atomic-gnome-kansei.yml
+++ b/recipes/t2-atomic-gnome-kansei.yml
@@ -16,7 +16,7 @@ image-version: 40 # latest is also supported if you want new updates ASAP
 # you can include multiple instances of the same module
 modules:
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync.yml #pulls fsync containerfile and overrides base image kernel
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-gnome.yml
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions

--- a/recipes/t2-atomic-gnome.yml
+++ b/recipes/t2-atomic-gnome.yml
@@ -12,7 +12,7 @@ image-version: 40
 
 modules:
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync.yml #pulls fsync containerfile and overrides base image kernel
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-gnome.yml
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions

--- a/recipes/t2-atomic-kansei.yml
+++ b/recipes/t2-atomic-kansei.yml
@@ -11,7 +11,7 @@ image-version: latest
 
 modules:
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync.yml #pulls fsync containerfile and overrides base image kernel
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   #- from-file: common/common-apps-gnome.yml
   - from-file: common/common-apps-cosmic.yml
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions

--- a/recipes/t2-atomic-plasma-kansei.yml
+++ b/recipes/t2-atomic-plasma-kansei.yml
@@ -12,7 +12,7 @@ image-version: 40
 
 modules:
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync.yml #pulls fsync containerfile and overrides base image kernel
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-plasma.yml
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions

--- a/recipes/t2-atomic-plasma.yml
+++ b/recipes/t2-atomic-plasma.yml
@@ -12,7 +12,7 @@ image-version: 40
 
 modules:
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync.yml #pulls fsync containerfile and overrides base image kernel
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-plasma.yml
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions

--- a/recipes/t2-atomic-river.yml
+++ b/recipes/t2-atomic-river.yml
@@ -11,7 +11,7 @@ base-image: ghcr.io/ublue-os/base-main
 image-version: latest
 
 modules:
-  - from-file: common/common-t2-enablement-fsync.yml #installs fsync kernel
+  - from-file: common/common-t2-kernel.yml #installs fsync kernel
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
   - from-file: common/common-files.yml
   - from-file: common/common-files-river.yml

--- a/recipes/t2-atomic-sway.yml
+++ b/recipes/t2-atomic-sway.yml
@@ -12,7 +12,7 @@ image-version: 40
 
 modules:
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync.yml #pulls fsync containerfile and overrides base image kernel
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-sway.yml
   - from-file: common/common-apps-sway.yml

--- a/recipes/t2-atomic-swayfx.yml
+++ b/recipes/t2-atomic-swayfx.yml
@@ -12,7 +12,7 @@ image-version: 40
 
 modules:
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync.yml #pulls fsync containerfile and overrides base image kernel
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-sway.yml
   # install the more-specific apps later, generally


### PR DESCRIPTION
fsync kernel, at least via the ublue containerfile is lacking apple_bce so we can no longer use it, so this pull request adds a file like the run that container copies and runs the fsync install script but that runs the t2linux kernel install via rpm-ostree override and a copr. quick and dirty find and replace to get builds working again, will investigate the cause of fsync dropping t2 support at a later time.

For the main t2-atomic images (everything other than Bluefin/Aurora remixes) there was no functional benefit to the fsync kernel over t2linux kernel anyway.