### PR TITLE
feat: add workflow for ublue-stable images

### DIFF
--- a/.github/workflows/build-ublue-stable.yml
+++ b/.github/workflows/build-ublue-stable.yml
@@ -1,0 +1,37 @@
+name: T2 Ublue Stabe Image Build
+on:
+  schedule:
+    - cron: "00 7 * * 2" # build weekly on tuesday
+                          # (bluefin/aurora builds at around 05:45 UTC)
+  # push:
+  #   paths-ignore: # don't rebuild if only documentation has changed
+  #     - "**.md"
+      
+  # pull_request:
+  workflow_dispatch: # allow manually triggering builds
+jobs:
+  bluebuild:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false # stop GH from cancelling all matrix builds if one fails
+      matrix:
+        recipe:
+          - t2-atomic-bluefin-dx-stable.yml
+          - t2-atomic-aurora-dx-stable.yml
+          #- t2-atomic-bazzite.yml
+          #- t2-atomic-bazzite-gnome.yml
+
+    steps:
+       # the build is fully handled by the reusable github action
+      - name: Image Build
+        uses: blue-build/github-action@v1.6
+        with:
+          recipe: ${{ matrix.recipe }}
+          cosign_private_key: ${{ secrets.SIGNING_SECRET }}
+          registry_token: ${{ github.token }}
+          pr_event_number: ${{ github.event.number }}

--- a/recipes/t2-atomic-aurora-dx-stable.yml
+++ b/recipes/t2-atomic-aurora-dx-stable.yml
@@ -1,0 +1,16 @@
+#
+# 2024 Chris Lauretano <os@cdl.sh>
+# this is an experiment to get bluefin-dx properly operational on T2 macs
+# now that bluefin uses fsync kernel that has basic T2 patches
+name: t2-atomic-aurora-dx
+# description will be included in the image's metadata
+description: Aurora DX Repackaged for Apple T2 Hardware.
+
+base-image: ghcr.io/ublue-os/aurora-dx
+image-version: stable
+
+modules:
+  - from-file: common/common-files.yml
+  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - type: signing # this sets up the proper policy & signing files for signed images to work fully
+  

--- a/recipes/t2-atomic-bluefin-dx-stable.yml
+++ b/recipes/t2-atomic-bluefin-dx-stable.yml
@@ -1,0 +1,16 @@
+#
+# 2024 Chris Lauretano <os@cdl.sh>
+# this is an experiment to get bluefin-dx properly operational on T2 macs
+# now that bluefin uses fsync kernel that has basic T2 patches
+name: t2-atomic-bluefin-dx
+# description will be included in the image's metadata
+description: Bluefin DX Repackaged for Apple T2 Hardware.
+
+base-image: ghcr.io/ublue-os/bluefin-dx
+image-version: stable
+
+modules:
+  - from-file: common/common-files.yml
+  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - type: signing # this sets up the proper policy & signing files for signed images to work fully
+  


### PR DESCRIPTION
Since "latest" bluefin/aurora are broken with fsync 6.11.2 not containing apple_bce module (still investigating), this pull request implements a ublue-stable workflow that builds images weekly (roughly in sync with the ublue github action) from their "stable" tagged images.