### PR TITLE
a potential fix for needing initramfs regen on local systems

### DIFF
--- a/files/scripts/t2-apple-bce.sh
+++ b/files/scripts/t2-apple-bce.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Tell this script to exit if there are any errors.
+# You should have this in every custom script, to ensure that your completed
+# builds actually ran successfully without any errors!
+set -oue pipefail
+
+echo 'T2-Atomic: Kernel Post-Install: Running Dracut to load apple_bce module at early boot'
+
+set -x; kver=$(cd /usr/lib/modules && echo *); dracut -vf /usr/lib/modules/$kver/initramfs.img $kver

--- a/files/system/etc/dracut.conf.d/cmdline.conf
+++ b/files/system/etc/dracut.conf.d/cmdline.conf
@@ -1,1 +1,1 @@
-kernel_cmdline+=" intel_iommu=on iommu=pt mem_sleep_default=s2idle"
+kernel_cmdline+=" intel_iommu=on iommu=pt mem_sleep_default=s2idle "

--- a/files/system/etc/dracut.conf.d/t2-bce.conf
+++ b/files/system/etc/dracut.conf.d/t2-bce.conf
@@ -1,2 +1,2 @@
 #load apple-bce early so keyboard works for LUKS and early boot
-force_drivers+=" apple-bce snd snd-pcm "
+force_drivers+=" apple_bce snd snd-pcm "

--- a/files/system/hyprland/etc/environment
+++ b/files/system/hyprland/etc/environment
@@ -1,0 +1,2 @@
+GTK_THEME=Adwaita:dark
+QT_STYLE_OVERRIDE=adwaita-dark

--- a/files/system/hyprland/usr/bin/share/wayland-sessions/hyprland.desktop
+++ b/files/system/hyprland/usr/bin/share/wayland-sessions/hyprland.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Hyprland
+Comment=An intelligent dynamic tiling Wayland compositor
+Exec=/usr/bin/starthyprland
+Type=Application

--- a/files/system/hyprland/usr/bin/starthyprland
+++ b/files/system/hyprland/usr/bin/starthyprland
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -oue pipefail
+
+
+hyprland_conf="$HOME/.config/hypr/hyprland.conf"
+base="/usr/share/hyprland/hyprland.conf"
+
+if [ -f "$hyprland_conf" ]; then
+    Hyprland -c "$hyprland_conf"
+else
+    Hyprland -c "$base"
+fi

--- a/files/system/usr/lib/dracut/dracut.conf.d/10-t2-apple-bce.conf
+++ b/files/system/usr/lib/dracut/dracut.conf.d/10-t2-apple-bce.conf
@@ -1,0 +1,1 @@
+force_drivers+=" apple_bce snd_pcm snd"

--- a/files/system/usr/lib/dracut/dracut.conf.d/10-t2-apple-bce.conf
+++ b/files/system/usr/lib/dracut/dracut.conf.d/10-t2-apple-bce.conf
@@ -1,1 +1,0 @@
-force_drivers+=" apple_bce snd_pcm snd"

--- a/recipes/common/common-apps-cosmic.yml
+++ b/recipes/common/common-apps-cosmic.yml
@@ -1,14 +1,14 @@
 # modules and things general to all cosmic recipes
 modules:
   - type: rpm-ostree
-    repos:
-      # TEMP: this is hardcoded as rawhide as of 20240531 as f40 repo isn't yet available (brand new copr)
-      - https://copr.fedorainfracloud.org/coprs/ryanabx/cosmic-epoch/repo/fedora-40/ryanabx-cosmic-epoch-fedora-%OS_VERSION%.repo
+  #  repos:
+  #    # TEMP: this is hardcoded as rawhide as of 20240531 as f40 repo isn't yet available (brand new copr)
+  #    - https://copr.fedorainfracloud.org/coprs/ryanabx/cosmic-epoch/repo/fedora-40/ryanabx-cosmic-epoch-fedora-%OS_VERSION%.repo
     install:
       - cosmic-desktop
 
 
-  - type: rpm-ostree
-    install:
-      - tuned
-      - gnome-keyring
+  #- type: rpm-ostree
+  #  install:
+  #    - tuned
+  #    - gnome-keyring

--- a/recipes/common/common-apps-hyprland.yml
+++ b/recipes/common/common-apps-hyprland.yml
@@ -1,0 +1,24 @@
+modules:
+  - type: rpm-ostree
+    install:
+      - hyprland
+      - waybar
+      - xdg-desktop-portal-hyprland
+      - hyprpaper
+      - hyprlock
+      - hypridle
+      - hyprpicker
+      - grim
+      - slurp
+      - swaync
+      - wlogout
+      
+  - type: rpm-ostree
+    repos:
+      - https://copr.fedorainfracloud.org/coprs/erikreider/SwayNotificationCenter/repo/fedora-%OS_VERSION%/erikreider-SwayNotificationCenter-fedora-%OS_VERSION%.repo
+    install:
+      - SwayNotificationCenter
+      
+  - type: script
+    snippets: 
+      #- "sed -i '/^UseIn/ s/$/,sway/' /usr/share/xdg-desktop-portal/portals/gnome-keyring.portal"

--- a/recipes/common/common-files-hyprland.yml
+++ b/recipes/common/common-files-hyprland.yml
@@ -1,0 +1,6 @@
+type: files
+files:
+  - source: system/hyprland/etc
+    destination: /etc
+  - source: system/hyprland/usr
+    destination: /usr

--- a/recipes/common/common-t2-enablement-f41.yml
+++ b/recipes/common/common-t2-enablement-f41.yml
@@ -28,3 +28,7 @@ modules:
       # using asahi-installer fork to package for use in fedora
       # it's hacky <3
       - apple-bcm-firmware.sh
+
+  - type: script
+    snippets: 
+      - "set -x; kver=$(cd /usr/lib/modules && echo *); dracut -vf /usr/lib/modules/$kver/initramfs.img $kver"

--- a/recipes/common/common-t2-enablement-f41.yml
+++ b/recipes/common/common-t2-enablement-f41.yml
@@ -31,4 +31,4 @@ modules:
 
   - type: script
     snippets: 
-      - "set -x; kver=$(cd /usr/lib/modules && echo *); dracut -vf /usr/lib/modules/$kver/initramfs.img $kver"
+      #- "set -x; kver=$(cd /usr/lib/modules && echo *); dracut -vf /usr/lib/modules/$kver/initramfs.img $kver"

--- a/recipes/common/common-t2-kernel.yml
+++ b/recipes/common/common-t2-kernel.yml
@@ -9,4 +9,4 @@ modules:
   - type: script
     scripts:
       - t2-kernel.sh
-      - t2-apple-bce.sh
+      #- t2-apple-bce.sh

--- a/recipes/common/common-t2-kernel.yml
+++ b/recipes/common/common-t2-kernel.yml
@@ -5,7 +5,8 @@ modules:
       - https://copr.fedorainfracloud.org/coprs/sharpenedblade/t2linux/repo/fedora-%OS_VERSION%/sharpenedblade-t2linux-fedora-%OS_VERSION%.repo
  
 
-# install the t2 kerel
+# install the t2 kernel 
   - type: script
     scripts:
       - t2-kernel.sh
+      - t2-apple-bce.sh

--- a/recipes/t2-atomic-cosmic-gnome-fsync-ba.yml
+++ b/recipes/t2-atomic-cosmic-gnome-fsync-ba.yml
@@ -12,11 +12,11 @@ image-version: 41
 alt-tags: 
   - fsync-ba
 modules:
-  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync-ba.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-cosmic.yml
   - from-file: common/common-files-gnome.yml
+  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-enablement-fsync-ba.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps.yml
   - from-file: common/common-apps-cosmic.yml
   - from-file: common/common-apps-gnome.yml #and gnome flatpaks etc because this has both

--- a/recipes/t2-atomic-cosmic-gnome.yml
+++ b/recipes/t2-atomic-cosmic-gnome.yml
@@ -11,11 +11,11 @@ base-image: ghcr.io/ublue-os/silverblue-main
 image-version: 41
 
 modules:
-  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-cosmic.yml
   - from-file: common/common-files-gnome.yml
+  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps.yml
   - from-file: common/common-apps-cosmic.yml
   - from-file: common/common-apps-gnome.yml #and gnome flatpaks etc because this has both

--- a/recipes/t2-atomic-cosmic-plasma.yml
+++ b/recipes/t2-atomic-cosmic-plasma.yml
@@ -11,11 +11,11 @@ base-image: ghcr.io/ublue-os/kinoite-main
 image-version: 41
 
 modules:
-  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-cosmic.yml
   - from-file: common/common-files-plasma.yml
+  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps-cosmic.yml
   - from-file: common/common-apps.yml
   - from-file: common/common-apps-plasma.yml #and plasma flatpaks etc because this has both

--- a/recipes/t2-atomic-cosmic.yml
+++ b/recipes/t2-atomic-cosmic.yml
@@ -7,16 +7,14 @@ name: t2-atomic-cosmic
 # description will be included in the image's metadata
 description: Fedora Atomic Cosmic base spin for Apple T2 Hardware
 
-base-image: ghcr.io/ublue-os/base-main
+base-image: quay.io/fedora-ostree-desktops/cosmic-atomic
 image-version: 41
 
 modules:
+  - from-file: common/common-files.yml
   - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
   - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
-  - from-file: common/common-files.yml
-  - from-file: common/common-files-cosmic.yml
   - from-file: common/common-apps.yml
-  - from-file: common/common-apps-cosmic.yml
 
   - type: signing # this sets up the proper policy & signing files for signed images to work fully
   

--- a/recipes/t2-atomic-gnome-fsync-ba.yml
+++ b/recipes/t2-atomic-gnome-fsync-ba.yml
@@ -12,10 +12,10 @@ image-version: 41
 alt-tags: 
   - fsync-ba
 modules:
-  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync-ba.yml  #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-gnome.yml
+  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-enablement-fsync-ba.yml  #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions
   - from-file: common/common-apps-gnome.yml #installs gnome flatpaks and such
 

--- a/recipes/t2-atomic-gnome-kansei.yml
+++ b/recipes/t2-atomic-gnome-kansei.yml
@@ -15,10 +15,10 @@ image-version: 41 # latest is also supported if you want new updates ASAP
 # module configuration, executed in order
 # you can include multiple instances of the same module
 modules:
-  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-gnome.yml
+  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions
   - from-file: common/common-kansei.yml
   - from-file: common/common-apps-gnome.yml #gnome flatpaks

--- a/recipes/t2-atomic-gnome.yml
+++ b/recipes/t2-atomic-gnome.yml
@@ -11,10 +11,10 @@ base-image: ghcr.io/ublue-os/silverblue-main
 image-version: 41
 
 modules:
-  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-gnome.yml
+  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions
   - from-file: common/common-apps-gnome.yml #installs gnome flatpaks and such
 

--- a/recipes/t2-atomic-kansei.yml
+++ b/recipes/t2-atomic-kansei.yml
@@ -12,18 +12,18 @@ image-version: 41
 modules:
   - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
   - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
-  #- from-file: common/common-apps-gnome.yml
-  - from-file: common/common-apps-cosmic.yml
+  - from-file: common/common-apps-hyprland.yml
+  - from-file: common/common-apps-plasma.yml
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions
   - from-file: common/common-apps-wayland.yml
   - from-file: common/common-apps-river.yml
-  - from-file: common/common-apps-sway.yml
+  #- from-file: common/common-apps-sway.yml
   - from-file: common/common-kansei.yml
   - from-file: common/common-files.yml
-  #- from-file: common/common-files-gnome.yml
-  #- from-file: common/common-files-cosmic.yml
+  - from-file: common/common-files-hyprland.yml
+  - from-file: common/common-files-plasma.yml
   - from-file: common/common-files-river.yml
-  - from-file: common/common-files-sway.yml
+  #- from-file: common/common-files-sway.yml
 
   - type: script
     snippets: 

--- a/recipes/t2-atomic-kansei.yml
+++ b/recipes/t2-atomic-kansei.yml
@@ -10,6 +10,11 @@ base-image: ghcr.io/ublue-os/sericea-main
 image-version: 41
 
 modules:
+  - from-file: common/common-files.yml
+  - from-file: common/common-files-hyprland.yml
+  - from-file: common/common-files-plasma.yml
+  - from-file: common/common-files-river.yml
+  #- from-file: common/common-files-sway.yml
   - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
   - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps-hyprland.yml
@@ -19,11 +24,7 @@ modules:
   - from-file: common/common-apps-river.yml
   #- from-file: common/common-apps-sway.yml
   - from-file: common/common-kansei.yml
-  - from-file: common/common-files.yml
-  - from-file: common/common-files-hyprland.yml
-  - from-file: common/common-files-plasma.yml
-  - from-file: common/common-files-river.yml
-  #- from-file: common/common-files-sway.yml
+
 
   - type: script
     snippets: 

--- a/recipes/t2-atomic-plasma-fsync-ba.yml
+++ b/recipes/t2-atomic-plasma-fsync-ba.yml
@@ -12,10 +12,10 @@ image-version: 41
 alt-tags:
   - fsync-ba
 modules:
-  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync-ba.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-plasma.yml
+  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-enablement-fsync-ba.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions
   - from-file: common/common-apps-plasma.yml #and plasma flatpaks etc because this has both
   - type: signing # this sets up the proper policy & signing files for signed images to work fully

--- a/recipes/t2-atomic-plasma-fsync.yml
+++ b/recipes/t2-atomic-plasma-fsync.yml
@@ -12,10 +12,10 @@ image-version: 41
 alt-tags:
   - fsync
 modules:
-  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync-f41.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-plasma.yml
+  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-enablement-fsync-f41.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions
   - from-file: common/common-apps-plasma.yml #and plasma flatpaks etc because this has both
   - type: signing # this sets up the proper policy & signing files for signed images to work fully

--- a/recipes/t2-atomic-plasma-kansei.yml
+++ b/recipes/t2-atomic-plasma-kansei.yml
@@ -11,10 +11,10 @@ base-image: ghcr.io/ublue-os/kinoite-main
 image-version: 41
 
 modules:
-  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-plasma.yml
+  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions
   - from-file: common/common-apps-plasma.yml #and plasma flatpaks etc because this has both
   - from-file: common/common-kansei.yml

--- a/recipes/t2-atomic-plasma.yml
+++ b/recipes/t2-atomic-plasma.yml
@@ -11,10 +11,10 @@ base-image: ghcr.io/ublue-os/kinoite-main
 image-version: 41
 
 modules:
-  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-plasma.yml
+  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps.yml #installs apps common across all the t2 editions
   - from-file: common/common-apps-plasma.yml #and plasma flatpaks etc because this has both
   - type: signing # this sets up the proper policy & signing files for signed images to work fully

--- a/recipes/t2-atomic-river.yml
+++ b/recipes/t2-atomic-river.yml
@@ -11,10 +11,10 @@ base-image: ghcr.io/ublue-os/base-main
 image-version: 41
 
 modules:
-  - from-file: common/common-t2-kernel.yml #installs fsync kernel
-  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
   - from-file: common/common-files.yml
   - from-file: common/common-files-river.yml
+  - from-file: common/common-t2-kernel.yml #installs fsync kernel
+  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
   - from-file: common/common-apps-wayland.yml
   - from-file: common/common-apps.yml
   - from-file: common/common-apps-river.yml

--- a/recipes/t2-atomic-sway-fsync-ba.yml
+++ b/recipes/t2-atomic-sway-fsync-ba.yml
@@ -12,10 +12,10 @@ image-version: 41
 alt-tags:
   - fsync-ba
 modules:
-  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-enablement-fsync-ba.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-files.yml
   - from-file: common/common-files-sway.yml
+  - from-file: common/common-t2-enablement.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-enablement-fsync-ba.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps-sway.yml
   - from-file: common/common-apps-wayland.yml
   - from-file: common/common-apps.yml

--- a/recipes/t2-atomic-sway.yml
+++ b/recipes/t2-atomic-sway.yml
@@ -10,11 +10,11 @@ description: Fedora Atomic Sway (sericea) spin for Apple T2 Hardware
 base-image: ghcr.io/ublue-os/sericea-main
 image-version: 41
 
-modules:
-  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
-  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
+modules:  
   - from-file: common/common-files.yml
   - from-file: common/common-files-sway.yml
+  - from-file: common/common-t2-enablement-f41.yml #installs t2 kernel, t2 grub arguments, and packages for enabling t2 hardware
+  - from-file: common/common-t2-kernel.yml #pulls fsync containerfile and overrides base image kernel
   - from-file: common/common-apps-sway.yml
   - from-file: common/common-apps-wayland.yml
   - from-file: common/common-apps.yml


### PR DESCRIPTION
to get apple_bce module to load early (needed for keyboard use for LUKS decryption) we need users to run rpm-ostree initramfs --enable which dramatically lengthens the update process (a lot of local CPU time). 